### PR TITLE
[Bootstrap 4 Theme]: Displaying errors like in components/forms

### DIFF
--- a/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
+++ b/Resources/views/Form/bootstrap_4_horizontal_layout.html.twig
@@ -33,6 +33,7 @@ col-sm-2
             <div class="{{ block('form_group_class') }}">
                 {{- form_widget(form, widget_attr) -}}
                 {{- form_help(form) -}}
+                {{- form_errors(form) -}}
             </div>
     {##}</div>
     {%- endif -%}
@@ -49,6 +50,7 @@ col-sm-2
             <div class="{{ block('form_group_class') }}">
                 {{- form_widget(form, widget_attr) -}}
                 {{- form_help(form) -}}
+                {{- form_errors(form) -}}
             </div>
         </div>
 {##}</fieldset>

--- a/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -1,5 +1,9 @@
 {% use "bootstrap_base_layout.html.twig" %}
 
+{# Disable errors shown on form labels #}
+
+{% block form_label_errors %}{% endblock form_label_errors %}
+
 {# Widgets #}
 
 {% block money_widget -%}
@@ -281,6 +285,7 @@
         {{- form_label(form) -}}
         {{- form_widget(form, widget_attr) -}}
         {{- form_help(form) -}}
+        {{- form_errors(form) -}}
     </{{ element|default('div') }}>
 {%- endblock form_row %}
 
@@ -288,13 +293,13 @@
 
 {% block form_errors -%}
     {%- if errors|length > 0 -%}
-        <span class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block">
+        <div class="{% if form is not rootform %}invalid-feedback{% else %}alert alert-danger{% endif %} d-block">
             {%- for error in errors -%}
                 <span class="d-block">
-                    <span class="form-error-icon badge badge-danger text-uppercase">{{ 'Error'|trans({}, 'validators') }}</span> <span class="form-error-message">{{ error.message }}</span>
+                    <span class="form-error-message">{{ error.message }}</span>
                 </span>
             {%- endfor -%}
-        </span>
+        </div>
     {%- endif %}
 {%- endblock form_errors %}
 


### PR DESCRIPTION
As for me, error displaying is much prettier with official bootstrap [component/forms](https://getbootstrap.com/docs/4.2/components/forms/#supported-elements).

Currect:
![2](https://user-images.githubusercontent.com/915531/51761697-d59a5280-20de-11e9-9a90-cda71c061671.jpg)

Proposed:
![1](https://user-images.githubusercontent.com/915531/51761699-d7641600-20de-11e9-9995-254a4038a355.jpg)
