### PR TITLE
Update bootstrap_4_layout.html.twig

### DIFF
--- a/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -123,7 +123,7 @@
         {%- set type = type|default('file') -%}
         {{- block('form_widget_simple') -}}
         {%- set label_attr = label_attr|merge({ class: (label_attr.class|default('') ~ ' custom-file-label')|trim }) -%}
-        <label for="{{ form.vars.id }}" {% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
+        <label for="{{ form.vars.id }}" lang="{{ app.request.locale }}" {% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
             {%- if attr.placeholder is defined and attr.placeholder is not none -%}
                 {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
             {%- endif -%}


### PR DESCRIPTION
Add lang attribute to enable translating the "Browse" after text using SCSS variables.
Example:
```
$custom-file-text: (
        en: "Browse",
        de: "Auswählen"
);
```

https://github.com/twbs/bootstrap/blob/v4.3.1/scss/_variables.scss#L640