### PR TITLE
Removed extra single quote in missing package exception message

### DIFF
--- a/Mime/NotificationEmail.php
+++ b/Mime/NotificationEmail.php
@@ -51,7 +51,7 @@ class NotificationEmail extends TemplatedEmail
         }
 
         if ($missingPackages) {
-            throw new \LogicException(sprintf('You cannot use "%s" if the "%s" Twig extension%s not available; try running "composer require "%s"".', static::class, implode('" and "', $missingPackages), \count($missingPackages) > 1 ? 's are' : ' is', implode(' ', array_keys($missingPackages))));
+            throw new \LogicException(sprintf('You cannot use "%s" if the "%s" Twig extension%s not available; try running "composer require %s"".', static::class, implode('" and "', $missingPackages), \count($missingPackages) > 1 ? 's are' : ' is', implode(' ', array_keys($missingPackages))));
         }
 
         parent::__construct($headers, $body);


### PR DESCRIPTION
The missing package copy had a double quote in the composer command disrupting the ability to copy/paste the command.

> try running "composer require "twig/cssinliner-extra twig/inky-extra"

This PR removes the quote before the package name so it reads:

> try running "composer require twig/cssinliner-extra twig/inky-extra"